### PR TITLE
Replace ConnectionBuilder with BuildConnection delegate

### DIFF
--- a/src/Linker/ILinkerConnectionBuilder.cs
+++ b/src/Linker/ILinkerConnectionBuilder.cs
@@ -5,7 +5,9 @@ namespace Linker
 {
     public interface ILinkerConnectionBuilder
     {
+        [Obsolete]
         Uri ConnectionString { get; }
+        [Obsolete]
         ConnectionSettings ConnectionSettings { get; }
         string ConnectionName { get; }
         IEventStoreConnection Build();

--- a/src/Linker/LinkerService.cs
+++ b/src/Linker/LinkerService.cs
@@ -60,9 +60,7 @@ namespace Linker
         public LinkerService(ILinkerConnectionBuilder originBuilder, ILinkerConnectionBuilder destinationBuilder,
             IFilterService filterService, Settings settings, ILinkerLogger logger) : this(
             originBuilder, destinationBuilder, new PositionRepository($"PositionStream-{destinationBuilder.ConnectionName}",
-                "PositionUpdated",
-                new ConnectionBuilder(destinationBuilder.ConnectionString, destinationBuilder.ConnectionSettings,
-                    $"position-{destinationBuilder.ConnectionName}")), filterService, settings, logger)
+                "PositionUpdated", destinationBuilder.Build), filterService, settings, logger)
         { }
 
         public LinkerService(ILinkerConnectionBuilder originBuilder, ILinkerConnectionBuilder destinationBuilder,
@@ -72,9 +70,7 @@ namespace Linker
 
         public LinkerService(ILinkerConnectionBuilder originBuilder, ILinkerConnectionBuilder destinationBuilder,
             IFilterService filterService, Settings settings) : this(originBuilder,destinationBuilder, new PositionRepository($"PositionStream-{destinationBuilder.ConnectionName}",
-            "PositionUpdated",
-            new ConnectionBuilder(destinationBuilder.ConnectionString, destinationBuilder.ConnectionSettings,
-                $"position-{destinationBuilder.ConnectionName}")), filterService, settings, new SimpleConsoleLogger(nameof(LinkerService))) { }
+            "PositionUpdated", destinationBuilder.Build), filterService, settings, new SimpleConsoleLogger(nameof(LinkerService))) { }
 
         public async Task<bool> Start()
         {


### PR DESCRIPTION
Replace PositionRepository's ConnectionBuilder with BuildConnection delegate. 

Mark unused properties in ILinkerBuilder interface with obsolete attribute for backward compatibility.

Close #15 