### PR TITLE
Fix: protect input metadata from mutation

### DIFF
--- a/src/Linker.App/Program.cs
+++ b/src/Linker.App/Program.cs
@@ -45,16 +45,13 @@ static class Program
                     link.Filters = new List<Filter> { defaultFilter };
                 }
 
-                var filters = link.Filters.Select(linkFilter => new Filter
-                {
-                    FilterOperation = linkFilter.FilterOperation,
-                    FilterType = linkFilter.FilterType,
-                    Value = linkFilter.Value
-                }).ToList();
+                var filters = link.Filters.Select(linkFilter => new Filter(linkFilter.FilterType, linkFilter.Value, linkFilter.FilterOperation)).ToList();
                 var filterService = new FilterService(filters);
-                var o = new LinkerConnectionBuilder(KurrentDBClientSettings.Create(link.Origin.ConnectionString),
+                var o = new LinkerConnectionBuilder(
+                    KurrentDBClientSettings.Create(link.Origin.ConnectionString),
                     link.Origin.ConnectionName);
-                var d = new LinkerConnectionBuilder(KurrentDBClientSettings.Create(link.Destination.ConnectionString),
+                var d = new LinkerConnectionBuilder(
+                    KurrentDBClientSettings.Create(link.Destination.ConnectionString),
                     link.Destination.ConnectionName);
                 origin ??= o;
                 var service = new LinkerService(o, d,

--- a/src/Linker/BufferedEvent.cs
+++ b/src/Linker/BufferedEvent.cs
@@ -19,8 +19,9 @@ public class BufferedEvent : IComparable<BufferedEvent>
         Created = created;
     }
 
-    public int CompareTo(BufferedEvent that)
+    public int CompareTo(BufferedEvent? that)
     {
+        if (that == null) return 1;
         if (that.StreamId.Equals(StreamId) && that.EventNumber.Equals(EventNumber) &&
             that.EventData.EventId.Equals(EventData.EventId))
             return 0;

--- a/src/Linker/Filter.cs
+++ b/src/Linker/Filter.cs
@@ -24,9 +24,4 @@ public class Filter
         Value = value;
         FilterOperation = filterOperation;
     }
-
-    public Filter()
-    {
-            
-    }
 }

--- a/src/Linker/Settings.cs
+++ b/src/Linker/Settings.cs
@@ -2,15 +2,14 @@
 
 public class Settings
 {
-    public Link[] Links { get; set; }
     public int MaxBufferSize { get; }
     public bool HandleConflicts { get; }
     public bool ResolveLinkTos { get; }
 
     public static Settings Default()
     {
-        return new Settings(SettingsDefaults.HandleConflicts, 
-            SettingsDefaults.MaxBufferSize, SettingsDefaults.ResolveLinkTos);
+        return new Settings(
+            SettingsDefaults.HandleConflicts, SettingsDefaults.MaxBufferSize, SettingsDefaults.ResolveLinkTos);
     }
 
     public Settings(bool handleConflicts, int maxBufferSize, bool resolveLinkTos)
@@ -23,19 +22,19 @@ public class Settings
 
 public class Link
 {
-    public Origin Origin { get; set; }
-    public Destination Destination { get; set; }
-    public IEnumerable<Filter> Filters { get; set; }
+    public required Origin Origin { get; set; }
+    public required Destination Destination { get; set; }
+    public required IEnumerable<Filter> Filters { get; set; }
 }
 
 public class Origin
 {
-    public string ConnectionString { get; set; }
-    public string ConnectionName { get; set; }
+    public required string ConnectionString { get; set; }
+    public required string ConnectionName { get; set; }
 }
 
 public class Destination
 {
-    public string ConnectionString { get; set; }
-    public string ConnectionName { get; set; }
+    public required string ConnectionString { get; set; }
+    public required string ConnectionName { get; set; }
 }


### PR DESCRIPTION
Prevents mutation of input metadata dictionary by creating defensive copies and using proper null handling in LinkerHelper.EnrichMetadata